### PR TITLE
Update signatures that take ByteBuffer to use struct, instead a pointer

### DIFF
--- a/include/bbs.h
+++ b/include/bbs.h
@@ -56,16 +56,16 @@ int32_t bbs_blind_commitment_context_add_message_string(uint64_t handle,
 
 int32_t bbs_blind_commitment_context_add_message_bytes(uint64_t handle,
                                                        uint32_t index,
-                                                       const struct ByteBuffer *const message,
+                                                       struct ByteBuffer message,
                                                        struct ExternError *err);
 
 int32_t bbs_blind_commitment_context_add_message_prehashed(uint64_t handle,
                                                            uint32_t index,
-                                                           const struct ByteBuffer *const message,
+                                                           struct ByteBuffer message,
                                                            struct ExternError *err);
 
 int32_t bbs_blind_commitment_context_set_public_key(uint64_t handle,
-                                                    const struct ByteBuffer *const public_key,
+                                                    struct ByteBuffer public_key,
                                                     struct ExternError *err);
 
 int32_t bbs_blind_commitment_context_set_nonce_string(uint64_t handle,
@@ -73,11 +73,11 @@ int32_t bbs_blind_commitment_context_set_nonce_string(uint64_t handle,
                                                       struct ExternError *err);
 
 int32_t bbs_blind_commitment_context_set_nonce_bytes(uint64_t handle,
-                                                     const struct ByteBuffer *const message,
+                                                     struct ByteBuffer message,
                                                      struct ExternError *err);
 
 int32_t bbs_blind_commitment_context_set_nonce_prehashed(uint64_t handle,
-                                                         const struct ByteBuffer *const message,
+                                                         struct ByteBuffer message,
                                                          struct ExternError *err);
 
 int32_t bbs_blind_sign_context_finish(uint64_t handle,
@@ -91,43 +91,43 @@ int32_t bbs_blind_sign_context_add_message_string(uint64_t handle,
 
 int32_t bbs_blind_sign_context_add_message_bytes(uint64_t handle,
                                                  uint32_t index,
-                                                 const struct ByteBuffer *const message,
+                                                 struct ByteBuffer message,
                                                  struct ExternError *err);
 
 int32_t bbs_blind_sign_context_add_message_prehashed(uint64_t handle,
                                                      uint32_t index,
-                                                     const struct ByteBuffer *const message,
+                                                     struct ByteBuffer message,
                                                      struct ExternError *err);
 
 int32_t bbs_blind_sign_context_set_secret_key(uint64_t handle,
-                                              const struct ByteBuffer *const secret_key,
+                                              struct ByteBuffer secret_key,
                                               struct ExternError *err);
 
 int32_t bbs_blind_sign_context_set_public_key(uint64_t handle,
-                                              const struct ByteBuffer *const public_key,
+                                              struct ByteBuffer public_key,
                                               struct ExternError *err);
 
 int32_t bbs_blind_sign_context_set_commitment(uint64_t handle,
-                                              const struct ByteBuffer *const public_key ,
+                                              struct ByteBuffer public_key ,
                                               struct ExternError *err);
 
 uint64_t bbs_blind_sign_context_init(struct ExternError *err);
 
 int32_t bbs_blind_signature_size(void);
 
-int32_t bbs_unblind_signature(const struct ByteBuffer *const blind_signature,
-                              const struct ByteBuffer *const blinding_factor,
+int32_t bbs_unblind_signature(struct ByteBuffer blind_signature,
+                              struct ByteBuffer blinding_factor,
                               struct ByteBuffer *unblind_signature,
                               struct ExternError *err);
 
 int32_t bbs_create_proof_context_finish(uint64_t handle, struct ByteBuffer *proof, struct ExternError *err);
 
 int32_t bbs_create_proof_context_set_public_key(uint64_t handle,
-                                                const struct ByteBuffer *const public_key,
+                                                struct ByteBuffer public_key,
                                                 struct ExternError *err);
 
 int32_t bbs_create_proof_context_set_signature(uint64_t handle,
-                                               const struct ByteBuffer *const signature ,
+                                               struct ByteBuffer signature ,
                                                struct ExternError *err);
 
 int32_t bbs_create_proof_context_set_nonce_string(uint64_t handle,
@@ -135,29 +135,29 @@ int32_t bbs_create_proof_context_set_nonce_string(uint64_t handle,
                                                   struct ExternError *err);
 
 int32_t bbs_create_proof_context_set_nonce_bytes(uint64_t handle,
-                                                 const struct ByteBuffer *const message,
+                                                 struct ByteBuffer message,
                                                  struct ExternError *err);
 
 int32_t bbs_create_proof_context_set_nonce_prehashed(uint64_t handle,
-                                                     const struct ByteBuffer *const message,
+                                                     struct ByteBuffer message,
                                                      struct ExternError *err);
 
 int32_t bbs_create_proof_context_add_proof_message_string(uint64_t handle,
                                                           const char *const message,
                                                           proof_message_t xtype,
-                                                          const struct ByteBuffer *const blinding_factor,
+                                                          struct ByteBuffer blinding_factor,
                                                           struct ExternError *err);
 
 int32_t bbs_create_proof_context_add_proof_message_bytes(uint64_t handle,
-                                                         const struct ByteBuffer *const message,
+                                                         struct ByteBuffer message,
                                                          proof_message_t xtype,
-                                                         const struct ByteBuffer *const blinding_factor,
+                                                         struct ByteBuffer blinding_factor,
                                                          struct ExternError *err);
 
 int32_t bbs_create_proof_context_add_proof_message_prehashed(uint64_t handle,
-                                                             const struct ByteBuffer *const message,
+                                                             struct ByteBuffer message,
                                                              proof_message_t xtype,
-                                                             const struct ByteBuffer *const blinding_factor,
+                                                             struct ByteBuffer blinding_factor,
                                                              struct ExternError *err);
 
 uint64_t bbs_create_proof_context_init(struct ExternError *err);
@@ -167,19 +167,19 @@ int32_t bbs_sign_context_add_message_string(uint64_t handle,
                                             struct ExternError *err);
 
 int32_t bbs_sign_context_add_message_bytes(uint64_t handle,
-                                           const struct ByteBuffer *const message,
+                                           struct ByteBuffer message,
                                            struct ExternError *err);
 
 int32_t bbs_sign_context_add_message_prehashed(uint64_t handle,
-                                               const struct ByteBuffer *const message,
+                                               struct ByteBuffer message,
                                                struct ExternError *err);
 
 int32_t bbs_sign_context_set_secret_key(uint64_t handle,
-                                        const struct ByteBuffer *const secret_key,
+                                        struct ByteBuffer secret_key,
                                         struct ExternError *err);
 
 int32_t bbs_sign_context_set_public_key(uint64_t handle,
-                                        const struct ByteBuffer *const public_key,
+                                        struct ByteBuffer public_key,
                                         struct ExternError *err);
 
 int32_t bbs_sign_context_finish(uint64_t handle, struct ByteBuffer *signature, struct ExternError *err);
@@ -189,11 +189,11 @@ uint64_t bbs_sign_context_init(struct ExternError *err);
 int32_t bbs_signature_size(void);
 
 int32_t bbs_verify_context_add_message_bytes(uint64_t handle,
-                                             const struct ByteBuffer *const message,
+                                             struct ByteBuffer message,
                                              struct ExternError *err);
 
 int32_t bbs_verify_context_add_message_prehashed(uint64_t handle,
-                                                 const struct ByteBuffer *const message,
+                                                 struct ByteBuffer message,
                                                  struct ExternError *err);
 
 int32_t bbs_verify_context_add_message_string(uint64_t handle,
@@ -201,10 +201,10 @@ int32_t bbs_verify_context_add_message_string(uint64_t handle,
                                               struct ExternError *err);
 
 int32_t bbs_verify_context_set_public_key(uint64_t handle,
-                                          const struct ByteBuffer *const public_key,
+                                          struct ByteBuffer public_key,
                                           struct ExternError *err);
 int32_t bbs_verify_context_set_signature(uint64_t handle,
-                                         const struct ByteBuffer *const signature,
+                                         struct ByteBuffer signature,
                                          struct ExternError *err);
 
 int32_t bbs_verify_context_finish(uint64_t handle, struct ExternError *err);
@@ -216,7 +216,7 @@ int32_t bbs_verify_blind_commitment_context_add_blinded(uint64_t handle,
                                                         struct ExternError *err);
 
 int32_t bbs_verify_blind_commitment_context_set_public_key(uint64_t handle,
-                                                           const struct ByteBuffer *const public_key,
+                                                           struct ByteBuffer public_key,
                                                            struct ExternError *err);
 
 int32_t bbs_verify_blind_commitment_context_set_nonce_string(uint64_t handle,
@@ -224,15 +224,15 @@ int32_t bbs_verify_blind_commitment_context_set_nonce_string(uint64_t handle,
                                                              struct ExternError *err);
 
 int32_t bbs_verify_blind_commitment_context_set_nonce_bytes(uint64_t handle,
-                                                            const struct ByteBuffer *const message,
+                                                            struct ByteBuffer message,
                                                             struct ExternError *err);
 
 int32_t bbs_verify_blind_commitment_context_set_nonce_prehashed(uint64_t handle,
-                                                                const struct ByteBuffer *const message,
+                                                                struct ByteBuffer message,
                                                                 struct ExternError *err);
 
 int32_t bbs_verify_blind_commitment_context_set_proof(uint64_t handle,
-                                                      const struct ByteBuffer *const proof,
+                                                      struct ByteBuffer proof,
                                                       struct ExternError *err);
 
 uint64_t bbs_verify_blind_commitment_context_init(struct ExternError *err);
@@ -247,11 +247,11 @@ int32_t bbs_verify_proof_context_finish(uint64_t handle, struct ExternError *err
 
 
 int32_t bbs_verify_proof_context_set_proof(uint64_t handle,
-                                           const struct ByteBuffer *const proof,
+                                           struct ByteBuffer proof,
                                            struct ExternError *err);
 
 int32_t bbs_verify_proof_context_set_public_key(uint64_t handle,
-                                                const struct ByteBuffer *const public_key,
+                                                struct ByteBuffer public_key,
                                                 struct ExternError *err);
 
 
@@ -260,11 +260,11 @@ int32_t bbs_verify_proof_context_set_nonce_string(uint64_t handle,
                                                   struct ExternError *err);
 
 int32_t bbs_verify_proof_context_set_nonce_bytes(uint64_t handle,
-                                                 const struct ByteBuffer *const message,
+                                                 struct ByteBuffer message,
                                                  struct ExternError *err);
 
 int32_t bbs_verify_proof_context_set_nonce_prehashed(uint64_t handle,
-                                                     const struct ByteBuffer *const message,
+                                                     struct ByteBuffer message,
                                                      struct ExternError *err);
 
 
@@ -273,34 +273,34 @@ int32_t bbs_verify_proof_context_add_message_string(uint64_t handle,
                                                     struct ExternError *err);
 
 int32_t bbs_verify_proof_context_add_message_bytes(uint64_t handle,
-                                                   const struct ByteBuffer *const message,
+                                                   struct ByteBuffer message,
                                                    struct ExternError *err);
 
 int32_t bbs_verify_proof_context_add_message_prehashed(uint64_t handle,
-                                                       const struct ByteBuffer *const message,
+                                                       struct ByteBuffer message,
                                                        struct ExternError *err);
 
 uint64_t bbs_verify_proof_context_init(struct ExternError *err);
 
-int32_t bls_generate_key(const struct ByteBuffer *const seed,
+int32_t bls_generate_key(struct ByteBuffer seed,
                          struct ByteBuffer *public_key,
                          struct ByteBuffer *secret_key,
                          struct ExternError *err);
 
-int32_t bls_get_public_key(const struct ByteBuffer *const secret_key ,
+int32_t bls_get_public_key(struct ByteBuffer secret_key ,
                            struct ByteBuffer *public_key,
                            struct ExternError *err);
 
 int32_t bls_public_key_size(void);
 
-int32_t bls_public_key_to_bbs_key(const struct ByteBuffer *const d_public_key,
+int32_t bls_public_key_to_bbs_key(struct ByteBuffer d_public_key,
                                   uint32_t message_count,
                                   struct ByteBuffer *public_key,
                                   struct ExternError *err);
 
 int32_t bls_secret_key_size(void);
 
-int32_t bls_secret_key_to_bbs_key(const struct ByteBuffer *const secret_key,
+int32_t bls_secret_key_to_bbs_key(struct ByteBuffer secret_key,
                                   uint32_t message_count,
                                   struct ByteBuffer *public_key,
                                   struct ExternError *err);

--- a/src/bbs_blind_sign.rs
+++ b/src/bbs_blind_sign.rs
@@ -99,8 +99,8 @@ pub extern "C" fn bbs_blind_sign_context_finish(
 }
 
 #[no_mangle]
-pub extern "C" fn bbs_unblind_signature(blind_signature: &ByteArray,
-                                        blinding_factor: &ByteArray,
+pub extern "C" fn bbs_unblind_signature(blind_signature: ByteArray,
+                                        blinding_factor: ByteArray,
                                         unblind_signature: &mut ByteBuffer,
                                         err: &mut ExternError) -> i32 {
     let res = call_with_result(err, || -> Result<ByteBuffer, BbsFfiError> {

--- a/src/bbs_sign.rs
+++ b/src/bbs_sign.rs
@@ -105,7 +105,7 @@ pub extern "C" fn bbs_verify_context_add_message_string(
 #[no_mangle]
 pub extern "C" fn bbs_verify_context_add_message_bytes(
     handle: u64,
-    message: &ByteArray,
+    message: ByteArray,
     err: &mut ExternError,
 ) -> i32 {
     bbs_sign_context_add_message_bytes(handle, message, err)
@@ -114,7 +114,7 @@ pub extern "C" fn bbs_verify_context_add_message_bytes(
 #[no_mangle]
 pub extern "C" fn bbs_verify_context_add_message_prehashed(
     handle: u64,
-    message: &ByteArray,
+    message: ByteArray,
     err: &mut ExternError,
 ) -> i32 {
     bbs_sign_context_add_message_prehashed(handle, message, err)
@@ -123,7 +123,7 @@ pub extern "C" fn bbs_verify_context_add_message_prehashed(
 #[no_mangle]
 pub extern "C" fn bbs_verify_context_set_public_key(
     handle: u64,
-    public_key: &ByteArray,
+    public_key: ByteArray,
     err: &mut ExternError,
 ) -> i32 {
     bbs_sign_context_set_public_key(handle, public_key, err)

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -15,7 +15,7 @@ pub extern "C" fn bls_public_key_size() -> i32 {
 
 #[no_mangle]
 pub extern "C" fn bls_generate_key(
-    seed: &ByteArray,
+    seed: ByteArray,
     public_key: &mut ByteBuffer,
     secret_key: &mut ByteBuffer,
     err: &mut ExternError,
@@ -30,7 +30,7 @@ pub extern "C" fn bls_generate_key(
 
 #[no_mangle]
 pub extern "C" fn bls_get_public_key(
-    secret_key: &ByteArray,
+    secret_key: ByteArray,
     public_key: &mut ByteBuffer,
     err: &mut ExternError,
 ) -> i32 {
@@ -51,7 +51,7 @@ pub extern "C" fn bls_get_public_key(
 
 #[no_mangle]
 pub extern "C" fn bls_secret_key_to_bbs_key(
-    secret_key: &ByteArray,
+    secret_key: ByteArray,
     message_count: u32,
     public_key: &mut ByteBuffer,
     err: &mut ExternError,
@@ -82,7 +82,7 @@ pub extern "C" fn bls_secret_key_to_bbs_key(
 
 #[no_mangle]
 pub extern "C" fn bls_public_key_to_bbs_key(
-    d_public_key: &ByteArray,
+    d_public_key: ByteArray,
     message_count: u32,
     public_key: &mut ByteBuffer,
     err: &mut ExternError,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,7 +26,7 @@ macro_rules! add_message_impl {
         #[no_mangle]
         pub extern "C" fn $name_bytes(
             handle: u64,
-            message: &ByteArray,
+            message: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let message = message.to_vec();
@@ -43,7 +43,7 @@ macro_rules! add_message_impl {
         #[no_mangle]
         pub extern "C" fn $name_prehash(
             handle: u64,
-            message: &ByteArray,
+            message: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let message = message.to_vec();
@@ -89,7 +89,7 @@ macro_rules! add_message_impl {
         pub extern "C" fn $name_bytes(
             handle: u64,
             index: $index,
-            message: &ByteArray,
+            message: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let message = message.to_vec();
@@ -108,7 +108,7 @@ macro_rules! add_message_impl {
         pub extern "C" fn $name_prehash(
             handle: u64,
             index: $index,
-            message: &ByteArray,
+            message: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let message = message.to_vec();
@@ -129,7 +129,7 @@ macro_rules! add_message_impl {
 macro_rules! add_bytes_impl {
     ($name:ident,$static:expr,$property:ident,$type:ident) => {
         #[no_mangle]
-        pub extern "C" fn $name(handle: u64, value: &ByteArray, err: &mut ExternError) -> i32 {
+        pub extern "C" fn $name(handle: u64, value: ByteArray, err: &mut ExternError) -> i32 {
             let value = value.to_vec();
             if value.is_empty() {
                 *err = ExternError::new_error(
@@ -173,7 +173,7 @@ macro_rules! add_bytes_impl {
         #[no_mangle]
         pub extern "C" fn $name_bytes(
             handle: u64,
-            value: &ByteArray,
+            value: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let value = value.to_vec();
@@ -193,7 +193,7 @@ macro_rules! add_bytes_impl {
         #[no_mangle]
         pub extern "C" fn $name_prehash(
             handle: u64,
-            value: &ByteArray,
+            value: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let value = value.to_vec();
@@ -226,7 +226,7 @@ macro_rules! add_proof_message_impl {
             handle: u64,
             message: FfiStr<'_>,
             xtype: ProofMessageType,
-            blinding_factor: &ByteArray,
+            blinding_factor: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let message = message.into_string();
@@ -264,9 +264,9 @@ macro_rules! add_proof_message_impl {
         #[no_mangle]
         pub extern "C" fn $name_bytes(
             handle: u64,
-            message: &ByteArray,
+            message: ByteArray,
             xtype: ProofMessageType,
-            blinding_factor: &ByteArray,
+            blinding_factor: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let message = message.to_vec();
@@ -304,9 +304,9 @@ macro_rules! add_proof_message_impl {
         #[no_mangle]
         pub extern "C" fn $name_prehash(
             handle: u64,
-            message: &ByteArray,
+            message: ByteArray,
             xtype: ProofMessageType,
-            blinding_factor: &ByteArray,
+            blinding_factor: ByteArray,
             err: &mut ExternError,
         ) -> i32 {
             let message = message.to_vec();

--- a/tests/bbs_test.c
+++ b/tests/bbs_test.c
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
     printf("Create key pair...");
     fflush(stdout);
 
-    if (bls_generate_key(seed, d_public_key, secret_key, err) != 0) {
+    if (bls_generate_key(*seed, d_public_key, secret_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
 
     printf("Create BBS key from BLS key that can sign %d messages...", message_count);
     fflush(stdout);
-    if (bls_public_key_to_bbs_key(d_public_key, message_count, public_key, err) != 0) {
+    if (bls_public_key_to_bbs_key(*d_public_key, message_count, public_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
 
     printf("Set public key in sign context...");
     fflush(stdout);
-    if (bbs_sign_context_set_public_key(handle, public_key, err) != 0) {
+    if (bbs_sign_context_set_public_key(handle, *public_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
 
     printf("Set secret key in sign context...");
     fflush(stdout);
-    if (bbs_sign_context_set_secret_key(handle, secret_key, err) != 0) {
+    if (bbs_sign_context_set_secret_key(handle, *secret_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
     printf("Set messages sign context...");
     fflush(stdout);
     for (i = 0; i < message_count; i++) {
-        if (bbs_sign_context_add_message_bytes(handle, messages[i], err) != 0) {
+        if (bbs_sign_context_add_message_bytes(handle, *messages[i], err) != 0) {
             printf("fail\n");
             goto Fail;
         }
@@ -154,7 +154,7 @@ int main(int argc, char** argv) {
 
     printf("Set messages to commitment...");
     fflush(stdout);
-    if (bbs_blind_commitment_context_add_message_bytes(handle, 0, messages[0], err) != 0) {
+    if (bbs_blind_commitment_context_add_message_bytes(handle, 0, *messages[0], err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -162,7 +162,7 @@ int main(int argc, char** argv) {
 
     printf("Set public key in blind sign commitment...");
     fflush(stdout);
-    if (bbs_blind_commitment_context_set_public_key(handle, public_key, err) != 0) {
+    if (bbs_blind_commitment_context_set_public_key(handle, *public_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
 
     printf("Set nonce in blind sign commitment...");
     fflush(stdout);
-    if (bbs_blind_commitment_context_set_nonce_bytes(handle, nonce, err) != 0) {
+    if (bbs_blind_commitment_context_set_nonce_bytes(handle, *nonce, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -203,7 +203,7 @@ int main(int argc, char** argv) {
 
     printf("Set public key in verify blind sign context...");
     fflush(stdout);
-    if (bbs_verify_blind_commitment_context_set_public_key(handle, public_key, err) != 0) {
+    if (bbs_verify_blind_commitment_context_set_public_key(handle, *public_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -211,7 +211,7 @@ int main(int argc, char** argv) {
 
     printf("Set nonce in verify blind sign context...");
     fflush(stdout);
-    if (bbs_verify_blind_commitment_context_set_nonce_bytes(handle, nonce, err) != 0) {
+    if (bbs_verify_blind_commitment_context_set_nonce_bytes(handle, *nonce, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -219,7 +219,7 @@ int main(int argc, char** argv) {
 
     printf("Set proof in verify blind sign context...");
     fflush(stdout);
-    if (bbs_verify_blind_commitment_context_set_proof(handle, blind_sign_context, err) != 0) {
+    if (bbs_verify_blind_commitment_context_set_proof(handle, *blind_sign_context, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -259,7 +259,7 @@ int main(int argc, char** argv) {
     printf("Set messages blind sign context...");
     fflush(stdout);
     for (i = 1; i < message_count; i++) {
-        if (bbs_blind_sign_context_add_message_bytes(handle, i, messages[i], err) != 0) {
+        if (bbs_blind_sign_context_add_message_bytes(handle, i, *messages[i], err) != 0) {
             printf("fail\n");
             goto Fail;
         }
@@ -268,7 +268,7 @@ int main(int argc, char** argv) {
 
     printf("Set public key in blind sign context...");
     fflush(stdout);
-    if (bbs_blind_sign_context_set_public_key(handle, public_key, err) != 0) {
+    if (bbs_blind_sign_context_set_public_key(handle, *public_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -276,7 +276,7 @@ int main(int argc, char** argv) {
 
     printf("Set secret key in blind sign context...");
     fflush(stdout);
-    if (bbs_blind_sign_context_set_secret_key(handle, secret_key, err) != 0) {
+    if (bbs_blind_sign_context_set_secret_key(handle, *secret_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -284,7 +284,7 @@ int main(int argc, char** argv) {
 
     printf("Set commitment in blind sign context...");
     fflush(stdout);
-    if (bbs_blind_sign_context_set_commitment(handle, commitment, err) != 0) {
+    if (bbs_blind_sign_context_set_commitment(handle, *commitment, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -300,7 +300,7 @@ int main(int argc, char** argv) {
 
     printf("Unblinding signature...");
     fflush(stdout);
-    if (bbs_unblind_signature(blind_signature, blinding_factor, unblind_signature, err) != 0) {
+    if (bbs_unblind_signature(*blind_signature, *blinding_factor, unblind_signature, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -318,7 +318,7 @@ int main(int argc, char** argv) {
     printf("Set messages in verify signature context...");
     fflush(stdout);
     for (i = 0; i < message_count; i++) {
-        if (bbs_verify_context_add_message_bytes(handle, messages[i], err) != 0) {
+        if (bbs_verify_context_add_message_bytes(handle, *messages[i], err) != 0) {
             printf("fail\n");
             goto Fail;
         }
@@ -327,7 +327,7 @@ int main(int argc, char** argv) {
 
     printf("Set public key in verify signature context...");
     fflush(stdout);
-    if (bbs_verify_context_set_public_key(handle, public_key, err) != 0) {
+    if (bbs_verify_context_set_public_key(handle, *public_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -335,7 +335,7 @@ int main(int argc, char** argv) {
 
     printf("Set signature in verify signature context...");
     fflush(stdout);
-    if (bbs_verify_context_set_signature(handle, unblind_signature, err) != 0) {
+    if (bbs_verify_context_set_signature(handle, *unblind_signature, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -360,16 +360,16 @@ int main(int argc, char** argv) {
 
     printf("Adding messages to proof context...");
     fflush(stdout);
-    if (bbs_create_proof_context_add_proof_message_bytes(handle, messages[0], Revealed, blinding_factor, err) != 0) {
+    if (bbs_create_proof_context_add_proof_message_bytes(handle, *messages[0], Revealed, *blinding_factor, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
-    if (bbs_create_proof_context_add_proof_message_bytes(handle, messages[1], Revealed, blinding_factor, err) != 0) {
+    if (bbs_create_proof_context_add_proof_message_bytes(handle, *messages[1], Revealed, *blinding_factor, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
     for (i = 2; i < message_count; i++) {
-        if (bbs_create_proof_context_add_proof_message_bytes(handle, messages[i], HiddenProofSpecificBlinding, blinding_factor, err) != 0) {
+        if (bbs_create_proof_context_add_proof_message_bytes(handle, *messages[i], HiddenProofSpecificBlinding, *blinding_factor, err) != 0) {
             printf("fail\n");
             goto Fail;
         }
@@ -378,7 +378,7 @@ int main(int argc, char** argv) {
 
     printf("Setting signature in proof context...");
     fflush(stdout);
-    if (bbs_create_proof_context_set_signature(handle, unblind_signature, err) != 0) {
+    if (bbs_create_proof_context_set_signature(handle, *unblind_signature, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -386,7 +386,7 @@ int main(int argc, char** argv) {
 
     printf("Set public key in proof context...");
     fflush(stdout);
-    if (bbs_create_proof_context_set_public_key(handle, public_key, err) != 0) {
+    if (bbs_create_proof_context_set_public_key(handle, *public_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -394,7 +394,7 @@ int main(int argc, char** argv) {
 
     printf("Set nonce in proof context...");
     fflush(stdout);
-    if (bbs_create_proof_context_set_nonce_bytes(handle, nonce, err) != 0) {
+    if (bbs_create_proof_context_set_nonce_bytes(handle, *nonce, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -424,7 +424,7 @@ int main(int argc, char** argv) {
             printf("fail\n");
             goto Fail;
         }
-        if (bbs_verify_proof_context_add_message_bytes(handle, messages[i], err) != 0) {
+        if (bbs_verify_proof_context_add_message_bytes(handle, *messages[i], err) != 0) {
             printf("fail\n");
             goto Fail;
         }
@@ -433,7 +433,7 @@ int main(int argc, char** argv) {
 
     printf("Set proof in verify proof context...");
     fflush(stdout);
-    if (bbs_verify_proof_context_set_proof(handle, proof, err) != 0) {
+    if (bbs_verify_proof_context_set_proof(handle, *proof, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -441,7 +441,7 @@ int main(int argc, char** argv) {
 
     printf("Set public key in verify proof context...");
     fflush(stdout);
-    if (bbs_verify_proof_context_set_public_key(handle, public_key, err) != 0) {
+    if (bbs_verify_proof_context_set_public_key(handle, *public_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -449,7 +449,7 @@ int main(int argc, char** argv) {
 
     printf("Set nonce in verify proof context..");
     fflush(stdout);
-    if (bbs_verify_proof_context_set_nonce_bytes(handle, nonce, err) != 0) {
+    if (bbs_verify_proof_context_set_nonce_bytes(handle, *nonce, err) != 0) {
         printf("fail\n");
         goto Fail;
     }


### PR DESCRIPTION
It seems that there's no need to pass a pointer to ByteBuffer when going through FFI. The byte arrays can be passed as ByteBuffer directly. The calling runtime will still be responsible for clearing the buffer.
This appears to be a cosmetic change, but for .NET specifically, it allows us to avoid using `unsafe` context anywhere, and just rely on the marshaling logic to handle structs.
I've tested this on Mac, Windows and Linux.