### PR TITLE
Allow proofs to be constructed when blinding factor isn't required

### DIFF
--- a/devops/Build.ps1
+++ b/devops/Build.ps1
@@ -53,6 +53,8 @@ switch ($Platform) {
         cargo build --target i686-linux-android --release
 
         mkdir $OutLocation/aarch64/
+        mkdir $OutLocation/armv7/
+        mkdir $OutLocation/i686/
         Copy-Item -Path ./target/aarch64-linux-android/release/libbbs.so -Destination $OutLocation/aarch64/
         Copy-Item -Path ./target/armv7-linux-androideabi/release/libbbs.so -Destination $OutLocation/armv7/
         Copy-Item -Path ./target/i686-linux-android/release/libbbs.so -Destination $OutLocation/i686/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ impl From<ByteBuffer> for ByteArray {
 }
 
 #[repr(C)]
+#[derive(PartialEq, Eq)]
 pub enum ProofMessageType {
     Revealed,
     HiddenProofSpecificBlinding,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -235,7 +235,7 @@ macro_rules! add_proof_message_impl {
                 return 1;
             }
             let bf = blinding_factor.to_vec();
-            if bf.is_empty() {
+            if bf.is_empty() && xtype == ProofMessageType::HiddenExternalBlinding {
                 *err = ExternError::new_error(ErrorCode::new(1), "Blinding Factor cannot be empty");
                 return 1;
             }


### PR DESCRIPTION
- Proofs should be constructed with revealed or proof specific hidden messages, without requiring blinding factor to be provided
- Build script update to create directories for android archs