### PR TITLE
Add explicit values as enum indices to ProofMessageType

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,9 @@ impl From<ByteBuffer> for ByteArray {
 #[repr(C)]
 #[derive(PartialEq, Eq)]
 pub enum ProofMessageType {
-    Revealed,
-    HiddenProofSpecificBlinding,
-    HiddenExternalBlinding,
+    Revealed = 1,
+    HiddenProofSpecificBlinding = 2,
+    HiddenExternalBlinding = 3,
 }
 
 #[repr(C)]


### PR DESCRIPTION
This ensures correct platform marshaling of values, specifically for runtimes that don't require `bbs.h`